### PR TITLE
Improve Android support

### DIFF
--- a/ExNavigatorStyles.js
+++ b/ExNavigatorStyles.js
@@ -9,9 +9,7 @@ import Colors from './Colors';
 import Layout from './Layout';
 
 let ExNavigatorStyles = StyleSheet.create({
-  navigator: {
-    backgroundColor: '#000',
-  },
+  navigator: { },
   scene: {
     backgroundColor: '#fff',
     top: 0,

--- a/ExRouteRenderer.js
+++ b/ExRouteRenderer.js
@@ -3,6 +3,7 @@
 import React from 'react-native';
 let {
   Image,
+  Platform,
   StyleSheet,
   Text,
   TouchableOpacity,
@@ -140,7 +141,12 @@ export default class ExRouteRenderer {
         return sceneConfig;
       }
     }
-    return ExSceneConfigs.PushFromRight;
+
+    if (Platform.OS === 'android') {
+      return ExSceneConfigs.Fade;
+    } else {
+      return ExSceneConfigs.PushFromRight;
+    }
   }
 
   @autobind

--- a/ExSceneConfigs.js
+++ b/ExSceneConfigs.js
@@ -174,13 +174,7 @@ let FromTheFront = {
 };
 
 let ExSceneConfigs = {
-  PushFromRight: {
-    ...Navigator.SceneConfigs.PushFromRight,
-    animationInterpolators: {
-      into: buildStyleInterpolator(FromTheRight),
-      out: buildStyleInterpolator(ToTheLeft),
-    },
-  },
+  Fade: Navigator.SceneConfigs.FadeAndroid,
   FloatFromRight: {
     ...Navigator.SceneConfigs.FloatFromRight,
     animationInterpolators: {
@@ -193,6 +187,13 @@ let ExSceneConfigs = {
     animationInterpolators: {
       into: buildStyleInterpolator(FromTheBottom),
       out: buildStyleInterpolator(Still),
+    },
+  },
+  PushFromRight: {
+    ...Navigator.SceneConfigs.PushFromRight,
+    animationInterpolators: {
+      into: buildStyleInterpolator(FromTheRight),
+      out: buildStyleInterpolator(ToTheLeft),
     },
   },
   ZoomFromFront: {


### PR DESCRIPTION
- Get rid of navigator backgroundColor style that caused fade scene config to have a black flash.
- Use the Fade sceneConfig by default on Android, and PushFromRight otherwise.
