### PR TITLE
Limit text in back button to one line

### DIFF
--- a/ExRouteRenderer.js
+++ b/ExRouteRenderer.js
@@ -95,11 +95,14 @@ class NavigationBarRouteMapper {
 
     if (title) {
       var buttonText =
-        <Text style={[
-          ExNavigatorStyles.barButtonText,
-          ExNavigatorStyles.barBackButtonText,
-          this._barButtonTextStyle,
-        ]}>
+        <Text 
+          numberOfLines={1} 
+          style={[
+            ExNavigatorStyles.barButtonText,
+            ExNavigatorStyles.barBackButtonText,
+            this._barButtonTextStyle,
+          ]}
+        >
           {title}
         </Text>;
     }


### PR DESCRIPTION
This allows to have a back button with a long title to automatically have an ellipsis when the title is wider than a specified width.
