### PR TITLE
Disable transitions while rendering

### DIFF
--- a/ExNavigatorMixin.js
+++ b/ExNavigatorMixin.js
@@ -9,51 +9,63 @@ export default {
   },
 
   jumpBack() {
-    return this.__navigator.jumpBack();
+    if (!this._transitionsDisabled())
+      return this.__navigator.jumpBack();
   },
 
   jumpForward() {
-    return this.__navigator.jumpForward();
+    if (!this._transitionsDisabled())
+      return this.__navigator.jumpForward();
   },
 
   jumpTo(route) {
-    return this.__navigator.jumpTo(route);
+    if (!this._transitionsDisabled())
+      return this.__navigator.jumpTo(route);
   },
 
   push(route) {
-    return this.__navigator.push(route);
+    if (!this._transitionsDisabled())
+      return this.__navigator.push(route);
   },
 
   pop() {
-    return this.__navigator.pop();
+    if (!this._transitionsDisabled())
+      return this.__navigator.pop();
   },
 
   replace(route) {
-    return this.__navigator.replace(route);
+    if (!this._transitionsDisabled())
+      return this.__navigator.replace(route);
   },
 
   replaceAtIndex(route, index) {
-    return this.__navigator.replaceAtIndex(route, index);
+    if (!this._transitionsDisabled())
+      return this.__navigator.replaceAtIndex(route, index);
   },
 
   replacePrevious(route) {
-    return this.__navigator.replacePrevious(route);
+    if (!this._transitionsDisabled())
+      return this.__navigator.replacePrevious(route);
   },
 
   resetTo(route) {
-    return this.__navigator.resetTo(route);
+    if (!this._transitionsDisabled())
+      return this.__navigator.resetTo(route);
   },
 
   immediatelyResetRouteStack(routeStack) {
-    return this.__navigator.immediatelyResetRouteStack(routeStack);
+    if (!this._transitionsDisabled())
+      return this.__navigator.immediatelyResetRouteStack(routeStack);
   },
 
   popToRoute(route) {
-    return this.__navigator.popToRoute(route);
+    if (!this._transitionsDisabled())
+      return this.__navigator.popToRoute(route);
   },
 
   popToTop() {
-    return this.__navigator.popToTop();
+    if (!this._transitionsDisabled())
+      return this.__navigator.popToTop();
   },
 
   // Convenience methods


### PR DESCRIPTION
It's quite easy currently to tap a button twice and end up routing to the same view two times, leading to it being on the route stack twice. This causes the back button to be misconfigured (because it's pointing "back" to itself), makes the user hit "back" twice and in general is confusing.

This PR adds an optional `blockDuringTransitions` prop (off by default) that disables mutating the route stack while a route transition is ongoing. When this functionality is activated even if the user hits a navigation button twice very quickly the navigation action will only take place once.
