### PR TITLE
Add renderBackButtonIcon for backButtonIcon customization

### DIFF
--- a/ExNavigator.js
+++ b/ExNavigator.js
@@ -34,6 +34,7 @@ export default class ExNavigator extends React.Component {
     barButtonIconStyle: Image.propTypes.style,
     renderNavigationBar: PropTypes.func,
     renderBackButton: PropTypes.func,
+    renderBackButtonIcon: PropTypes.func,
     augmentScene: PropTypes.func,
   };
 

--- a/ExRouteRenderer.js
+++ b/ExRouteRenderer.js
@@ -112,17 +112,26 @@ class NavigationBarRouteMapper {
         </Text>;
     }
 
-    return (
-      <TouchableOpacity
-        pressRetentionOffset={ExNavigatorStyles.barButtonPressRetentionOffset}
-        onPress={() => this._navigator.pop()}
-        style={[ExNavigatorStyles.barBackButton, styles.backButtonStyle]}>
+    let backButtonIcon;
+    if (this._navigator.props.renderBackButtonIcon) {
+      backButtonIcon = this._navigator.props.renderBackButtonIcon();
+    } else {
+      backButtonIcon = (
         <BackIcon
           style={[
             ExNavigatorStyles.barButtonIcon,
             this._barButtonIconStyle,
           ]}
         />
+      );
+    }
+
+    return (
+      <TouchableOpacity
+        pressRetentionOffset={ExNavigatorStyles.barButtonPressRetentionOffset}
+        onPress={() => this._navigator.pop()}
+        style={[ExNavigatorStyles.barBackButton, styles.backButtonStyle]}>
+        {backButtonIcon}
         {buttonText}
       </TouchableOpacity>
     );


### PR DESCRIPTION
08dc150 is good if we would like to customise all the logic of backButton.
However, there are some good part of internal logics, e.g. https://github.com/exponentjs/ex-navigator/blob/master/ExRouteRenderer.js#L94-L113.
This change proposes a way to only customise the BackIcon component from ExNavigator.
Please feel free to comment and we should discuss here.
Now I think there are too many options (propTypes) in ExNavigator interface.
While enabling `renderBackButtonIcon`, `barButtonIconStyle` is useless and not sure if that would be implicit or not.
