### PR TITLE
Add `resetTo` method to ExNavigator

### DIFF
--- a/ExNavigatorMixin.js
+++ b/ExNavigatorMixin.js
@@ -40,6 +40,10 @@ export default {
     return this.__navigator.replacePrevious(route);
   },
 
+  resetTo(route) {
+    return this.__navigator.resetTo(route);
+  },
+
   immediatelyResetRouteStack(routeStack) {
     return this.__navigator.immediatelyResetRouteStack(routeStack);
   },


### PR DESCRIPTION
I'm not sure if there is a reason isn't there since it seems to be implemented in React-Native's `Navigator` for a long time.
Let me know if that's the case or if I can improve something!
