### PR TITLE
Don't scale navbar text

### DIFF
--- a/ExRouteRenderer.js
+++ b/ExRouteRenderer.js
@@ -51,7 +51,7 @@ class NavigationBarRouteMapper {
     }
 
     return (
-      <Text style={[ExNavigatorStyles.barTitleText, this._titleStyle]}>
+      <Text style={[ExNavigatorStyles.barTitleText, this._titleStyle]} allowFontScaling={false}>
         {shortenTitle(route.getTitle(this._navigator, index, state))}
       </Text>
     );
@@ -107,7 +107,8 @@ class NavigationBarRouteMapper {
             ExNavigatorStyles.barButtonText,
             ExNavigatorStyles.barBackButtonText,
             this._barButtonTextStyle,
-          ]}>
+          ]}
+          allowFontScaling={false}>
           {title}
         </Text>;
     }


### PR DESCRIPTION
This PR disables scaling for navbar text in case the user has changed system font size.
This is the way the system/apple apps work.

Before: 
<img width="331" alt="screen shot 2016-02-24 at 13 32 03" src="https://cloud.githubusercontent.com/assets/2223418/13285824/54929e56-dafd-11e5-9152-5632f6d1710f.png">

After:
<img width="313" alt="screen shot 2016-02-24 at 13 32 54" src="https://cloud.githubusercontent.com/assets/2223418/13285825/59b379e6-dafd-11e5-9ccf-31ca400f59ef.png">
