### PR TITLE
Separate React from ReactNative

### DIFF
--- a/ExNavigator.js
+++ b/ExNavigator.js
@@ -1,9 +1,9 @@
 'use strict';
 
-import React, {
+import React, { PropTypes } from 'react';
+import {
   Image,
   Navigator,
-  PropTypes,
   Text,
   View,
 } from 'react-native';

--- a/ExRouteRenderer.js
+++ b/ExRouteRenderer.js
@@ -1,6 +1,7 @@
 'use strict';
 
-import React, {
+import React from 'react';
+import {
   Image,
   Platform,
   StyleSheet,


### PR DESCRIPTION
In React Native 0.25, React Native stops wrapping shared React functionality (createClass, PropTypes etc.) and expects end users to import these from the react package instead. This PR implements that behavior.
