### PR TITLE
Shorten title length parameter

### DIFF
--- a/ExNavigator.js
+++ b/ExNavigator.js
@@ -37,6 +37,7 @@ export default class ExNavigator extends React.Component {
     renderNavigationBar: PropTypes.func,
     renderBackButton: PropTypes.func,
     augmentScene: PropTypes.func,
+    shortenTitle: PropTypes.func,
   };
 
   static defaultProps = {
@@ -54,6 +55,7 @@ export default class ExNavigator extends React.Component {
       titleStyle: props.titleStyle,
       barButtonTextStyle: props.barButtonTextStyle,
       barButtonIconStyle: props.barButtonIconStyle,
+      shortenTitle: props.shortenTitle,
     });
 
     this._renderScene = this._renderScene.bind(this);

--- a/ExRouteRenderer.js
+++ b/ExRouteRenderer.js
@@ -36,11 +36,7 @@ class NavigationBarRouteMapper {
     this._titleStyle = styles.titleStyle;
     this._barButtonTextStyle = styles.barButtonTextStyle;
     this._barButtonIconStyle = styles.barButtonIconStyle;
-    if (styles.shortenTitle != null) {
-      this._shortenTitle = styles.shortenTitle;
-    } else {
-      this._shortenTitle = shortenTitle;
-    }
+    this._shortenTitle = (styles.shortenTitle != null) ? styles.shortenTitle : shortenTitle;
   }
 
   Title(

--- a/ExRouteRenderer.js
+++ b/ExRouteRenderer.js
@@ -27,6 +27,7 @@ type BarStyles = {
   titleStyle?: any;
   barButtonTextStyle?: any;
   barButtonIconStyle?: any;
+  shortenTitle?: any;
 };
 
 class NavigationBarRouteMapper {
@@ -35,6 +36,11 @@ class NavigationBarRouteMapper {
     this._titleStyle = styles.titleStyle;
     this._barButtonTextStyle = styles.barButtonTextStyle;
     this._barButtonIconStyle = styles.barButtonIconStyle;
+    if (styles.shortenTitle != null) {
+      this._shortenTitle = styles.shortenTitle;
+    } else {
+      this._shortenTitle = shortenTitle;
+    }
   }
 
   Title(
@@ -53,7 +59,7 @@ class NavigationBarRouteMapper {
 
     return (
       <Text style={[ExNavigatorStyles.barTitleText, this._titleStyle]} allowFontScaling={false}>
-        {shortenTitle(route.getTitle(this._navigator, index, state))}
+        {this._shortenTitle(route.getTitle(this._navigator, index, state))}
       </Text>
     );
   }


### PR DESCRIPTION
Following on from the issue #95 , I added a function parameter "shortenTitle".

In case it's not provided, it uses the default shortenTitle function there was in [ExRouteRenderer](https://github.com/exponentjs/ex-navigator/blob/master/ExRouteRenderer.js) component.

Cheers,
