### PR TITLE
Fix some missing separation between React and React Native

### DIFF
--- a/ExNavigatorIcons.js
+++ b/ExNavigatorIcons.js
@@ -1,6 +1,6 @@
 'use strict';
-
-import React, {
+import React, { Component } from 'react';
+import {
   StyleSheet,
   View,
 } from 'react-native';
@@ -10,7 +10,7 @@ import Layout from './Layout';
 
 let { sources, ...iconPropTypes } = ResponsiveImage.propTypes;
 
-export class BackIcon extends React.Component {
+export class BackIcon extends Component {
   static propTypes = iconPropTypes;
 
   render() {

--- a/ExSceneConfigs.js
+++ b/ExSceneConfigs.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import React, {
+import {
   Dimensions,
   Navigator,
   PixelRatio,


### PR DESCRIPTION
I've noticed there was still some warnings after 41ab35e12d4269f32485586a8bdf77b0606d92a4.
This PR should fix everything ;)
