### PR TITLE
Remove duplicate default export on ExRouteRenderer

### DIFF
--- a/ExRouteRenderer.js
+++ b/ExRouteRenderer.js
@@ -257,5 +257,3 @@ let styles = StyleSheet.create({
     alignItems: 'center',
   },
 });
-
-export default ExRouteRenderer;


### PR DESCRIPTION
There is already an `export default` at the [class definition](https://github.com/exponentjs/ex-navigator/blob/master/ExRouteRenderer.js#L145).

Since to have been here for a long time but just broke my project. 
