### PR TITLE
Remove duplicate default export

### DIFF
--- a/ExRouteRenderer.js
+++ b/ExRouteRenderer.js
@@ -257,5 +257,3 @@ let styles = StyleSheet.create({
     alignItems: 'center',
   },
 });
-
-export default ExRouteRenderer;


### PR DESCRIPTION
After updating to RN 0.32.0-rc.0 and React 15.3.1 I was getting the following error when trying to compile -

```
[node-haste] Encountered an error while persisting cache:
> SyntaxError: /Users/robertwalker/code/PTApp/node_modules/@exponent/react-native-navigator/ExRouteRenderer.js: Only one default export allowed per module.
>   259 | });
>   260 | 
> > 261 | export default ExRouteRenderer;
>       | ^
>   262 | 
```

So I have removed the offending duplicate default export.
