### PR TITLE
Fix screens not animating correctly

### DIFF
--- a/vendor/buildStyleInterpolator.js
+++ b/vendor/buildStyleInterpolator.js
@@ -457,8 +457,9 @@ for (var varIndex = 0; varIndex < 16; varIndex++) {
 }
 var setNextMatrixAndDetectChange = function(orderedMatrixOperations) {
   var fn = [
-    '  var transformMatrix = result.transformMatrix !== undefined ? ' +
-    'result.transformMatrix : (result.transformMatrix = []);'
+    '  var transform = result.transform !== undefined ? ' +
+    'result.transform : (result.transform = [{ matrix: [] }]);' +
+    '  var transformMatrix = transform[0].matrix;'
   ];
   fn.push.apply(
     fn,


### PR DESCRIPTION
When upgrading to react-native 0.44 from 0.42.3 the screen would not animate anymore when pushing or popping a route. As seen here:

![broken](https://cloud.githubusercontent.com/assets/410305/26200005/9032124e-3bcc-11e7-9367-776e85ce2fd8.gif)

After this fix:

![fixed](https://cloud.githubusercontent.com/assets/410305/26200010/9381211a-3bcc-11e7-9741-b3c3e656b04b.gif)

The solution is basically taken from https://github.com/facebookarchive/react-native-custom-components/blob/master/src/buildStyleInterpolator.js. I first just used that file and then boiled it down to a minimal diff.
