### PR TITLE
Update @expo/react-native-responsive-image

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/expo/ex-navigator#readme",
   "dependencies": {
-    "@expo/react-native-responsive-image": "^1.2.1",
+    "@expo/react-native-responsive-image": "github:expo/react-native-responsive-image",
     "invariant": "^2.2.0",
     "prop-types": "^15.5.8",
     "react-clone-referenced-element": "^1.0.1",


### PR DESCRIPTION
For standalone `PropTypes` patch in https://github.com/expo/react-native-responsive-image/pull/7 that has not been tagged in a release yet.